### PR TITLE
Update launch files to load URDF directly and remove namespace prefixes from TF frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Requires
 #### **2. Namespace Removal in URDF**
 - The original URDF files included `${namespace}` prefixes for all TF frames  
   (e.g., `namespace_base_link`, `namespace_base_scan`, etc.).
-  **After removing the namespace:**
+- **After removing the namespace:**
   base_footprint → base_link → base_scan
   
-  **Instead of (previously with namespace):**
+-  **Instead of (previously with namespace):**
   turtlebot3/base_footprint → turtlebot3/base_link → turtlebot3/base_scan
   
 - This makes the TF naming consistent with standard ROS 2 TurtleBot3 setups and  

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Requires
 #### **2. Namespace Removal in URDF**
 - The original URDF files included `${namespace}` prefixes for all TF frames  
   (e.g., `namespace_base_link`, `namespace_base_scan`, etc.).
+  **After removing the namespace:**
   base_footprint → base_link → base_scan
-  instead of:
+  
+  **Instead of (previously with namespace):**
   turtlebot3/base_footprint → turtlebot3/base_link → turtlebot3/base_scan
   
 - This makes the TF naming consistent with standard ROS 2 TurtleBot3 setups and  

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Requires
   - `ros-<distro>-nav2-bringup`
   - `ros-<distro>-ros-ign-gazebo`
   - `ros-<distro>-ros-ign-bridge`
+  - `ros-<distro>-turtlebot3-description`

--- a/README.md
+++ b/README.md
@@ -25,3 +25,36 @@ Requires
   - `ros-<distro>-ros-ign-gazebo`
   - `ros-<distro>-ros-ign-bridge`
   - `ros-<distro>-turtlebot3-description`
+
+---
+
+### ✅ Recent Updates
+
+
+#### **1. Robot State Publisher Update**
+- The `robot_state_publisher.launch.py` was modified to **load the URDF model directly** from  
+  `turtlebot3_description/urdf/turtlebot3_waffle.urdf` instead of the SDF version.
+
+- This change aligns with the current ROS 2 Humble and Ignition Gazebo workflows,  
+  which use URDF as the standard robot description format for `robot_state_publisher`.
+
+#### **2. Namespace Removal in URDF**
+- The original URDF files included `${namespace}` prefixes for all TF frames  
+  (e.g., `namespace_base_link`, `namespace_base_scan`, etc.).
+  base_footprint → base_link → base_scan
+  instead of:
+  turtlebot3/base_footprint → turtlebot3/base_link → turtlebot3/base_scan
+  
+- This makes the TF naming consistent with standard ROS 2 TurtleBot3 setups and  
+simplifies integration with Nav2 and other TF consumers.
+
+---
+
+### 🧩 Summary of Improvements
+| Area | Change | Benefit |
+|------|---------|----------|
+| Robot State Publisher | Use URDF instead of SDF | Compatibility with Humble |
+| TF Frames | Removed `${namespace}` prefixes | Cleaner TF tree, easier debugging |
+
+---
+

--- a/turtlebot3/launch/robot_state_publisher.launch.py
+++ b/turtlebot3/launch/robot_state_publisher.launch.py
@@ -1,35 +1,41 @@
-
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-import xacro
-
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
 def generate_launch_description():
-
+    TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'waffle')
     use_sim_time = LaunchConfiguration('use_sim_time', default='true')
 
-    sdf = os.path.join(
-        get_package_share_directory('turtlebot3'),
-        'models', 'turtlebot3', 'model.sdf')
+    # Path to URDF file
+    urdf_file = os.path.join(
+        get_package_share_directory('turtlebot3_description'),
+        'urdf',
+        f'turtlebot3_{TURTLEBOT3_MODEL}.urdf'
+    )
 
-    doc = xacro.parse(open(sdf))
-    xacro.process_doc(doc)
+    # Read and clean the URDF
+    with open(urdf_file, 'r') as infp:
+        robot_desc = infp.read().replace('${namespace}', '')  # remove namespace placeholders
 
+    # Launch robot_state_publisher
     return LaunchDescription([
         DeclareLaunchArgument(
             'use_sim_time',
             default_value='true',
             description='Use simulation (Gazebo) clock if true'),
+
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
             name='robot_state_publisher',
             output='screen',
-            parameters=[{'use_sim_time': use_sim_time,
-                         'robot_description': doc.toxml()}]),
+            parameters=[{
+                'use_sim_time': use_sim_time,
+                'robot_description': robot_desc
+            }],
+        ),
     ])
+


### PR DESCRIPTION
Launch and URDF Updates

Updated robot_state_publisher.launch.py to load the URDF file directly from
turtlebot3_description/urdf/turtlebot3_waffle.urdf instead of parsing the SDF/Xacro model.
→ Ensures compatibility with ROS 2 Humble and modern Ignition Gazebo workflows.

Removed the ${namespace} prefix from all TF frames for cleaner naming.

Before:
turtlebot3/base_footprint → turtlebot3/base_link → turtlebot3/base_scan

After:
base_footprint → base_link → base_scan

→ Results in a simplified, standard TF tree consistent with TurtleBot3 and Nav2 conventions.